### PR TITLE
image_ids has wrong type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "image_id" {
 
 variable "image_ids" {
   description = "A list of ecs image IDs to launch one or more ecs instances."
-  type        = string
+  type        = list(string)
   default     = []
 }
 


### PR DESCRIPTION
image_ids is a list of strings, so the type has to be corrected, otherwise it will always return an error while initializing Terraform